### PR TITLE
add #!/usr/bin/env node to bin file

### DIFF
--- a/bin/gh-travis.js
+++ b/bin/gh-travis.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 /*
  * Copyright 2013, All Rights Reserved.
  *


### PR DESCRIPTION
Based on this issue https://github.com/node-gh/gh-travis/issues/8 , the npm needs to add #!/usr/bin/env node to bin file to work properly on windows to generate the *.cmd file correctly.
